### PR TITLE
Adding lock in DB transaction to get and update 'next task'

### DIFF
--- a/workflow_handler/views.py
+++ b/workflow_handler/views.py
@@ -6,6 +6,7 @@ from rest_framework.parsers import MultiPartParser
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from workflow_handler.csv2task import process_csv
+from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, get_list_or_404
 from rest_framework.pagination import LimitOffsetPagination
@@ -163,14 +164,15 @@ class NextTaskView(APIView):
     def get(self, request, workflow_id):
         workflow = Workflow.objects.get(id=workflow_id)
         queryset = self.get_queryset()
-        obj = queryset.filter(Q(status="pending") & Q(workflow=workflow)).first()
-        task = self.serializer_class(obj).data
-        if obj:
-            obj.status = "assigned"
-            obj.save()
-            return Response(task)
-        else:
-            return Response(status=204)
+        with transaction.atomic():
+            obj = queryset.select_for_update().filter(Q(status="pending") & Q(workflow=workflow)).first()
+            task = self.serializer_class(obj).data
+            if obj:
+                obj.status = "assigned"
+                obj.save()
+                return Response(task)
+            else:
+                return Response(status=204)
 
 
 class CreateTaskView(CreateAPIView):


### PR DESCRIPTION
Based off master since I couldn't get develop to run locally on my machine, so probably better to merge into master directly since it's a small change anyway.

The duplicates issue is fixed as per the stress test results below (100 workers, 10 cycles, 5sec AHT):

```
Starting analysis...
Checking whether there is any duplicate task...
OK: No duplicates
Computing response time stats...
Response times for 'Next task':
0th percentile: 16ms
50th percentile: 41ms
75th percentile: 67ms
80th percentile: 76ms
85th percentile: 91ms
90th percentile: 117ms
95th percentile: 158ms
99th percentile: 348ms
100th percentile: 440ms
Response times for 'Complete task':
0th percentile: 16ms
50th percentile: 36ms
75th percentile: 55ms
80th percentile: 63ms
85th percentile: 72ms
90th percentile: 84ms
95th percentile: 117ms
99th percentile: 182ms
100th percentile: 329ms
Response times per task (aggregate complete and load next task):
0th percentile: 37ms
50th percentile: 88ms
75th percentile: 129ms
80th percentile: 140ms
85th percentile: 162ms
90th percentile: 185ms
95th percentile: 237ms
99th percentile: 370ms
100th percentile: 487ms
```