### PR TITLE
Fix pending accounting

### DIFF
--- a/user_handler/metrics.py
+++ b/user_handler/metrics.py
@@ -4,7 +4,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from django.utils import timezone
-from django.db.models import Q, Count, F, Avg
+from django.db.models import Q, F, Avg
 from user_handler.permissions import IsOrgAdmin
 from workflow_handler.models import Task
 
@@ -31,8 +31,8 @@ def get_pending(**kwargs):
         & Q(workflow__disabled=False)
         & Q(created_at__lte=kwargs["end_time"])
         & Q(Q(completed_at__gt=kwargs["end_time"]) | Q(completed_at=None))
-    ).aggregate(pending=Count("status"))
-    return result["pending"]
+    ).count()
+    return result
 
 
 def get_aht(**kwargs):


### PR DESCRIPTION
We can't properly account for pending tasks in the past without leveraging the `completed_at` data.