### PR TITLE
Hard setting encoding to utf-8 fixes the emoji issue

### DIFF
--- a/workflow_handler/utils.py
+++ b/workflow_handler/utils.py
@@ -1,3 +1,5 @@
+import cchardet
+
 from .models import WorkflowHook
 
 
@@ -42,4 +44,4 @@ def unidecode(text):
     try:
         return text.decode("utf-8")
     except UnicodeDecodeError:
-        return text.decode()
+        return text.decode(cchardet.detect(text)["encoding"])


### PR DESCRIPTION
Tested locally:

- By uploading a CSV through a Python script
- By uploading a CSV through the frontend

Went through quite a rabbit hole and it seems like utf-8 is the standard nowadays. Don't think we need to guess the encoding, and as we saw through this bug maybe this approach isn't infallible?

The issue I had was cchardet returning `None` when attempting to guess the encoding of the CSV content.