### PR TITLE
Hotfix Zapier Trigger bug

### DIFF
--- a/external/zapier.py
+++ b/external/zapier.py
@@ -230,7 +230,9 @@ class GetZapierTaskSampleData(APIView):
             Q(organization__in=organizations)
             & Q(pk=self.request.query_params["workflow_id"])
         )
-        return Task.objects.filter(workflow=workflows.first(), status="completed")
+        return Task.objects.filter(
+            workflow=workflows.first(), status="completed"
+        ).order_by("-completed_at")
 
     def get_workflow(self):
         user = self.request.user
@@ -243,8 +245,8 @@ class GetZapierTaskSampleData(APIView):
 
     def get_dict_or_sample(self, queryset):
         if queryset.exists():
-            task = queryset.first()
-            perform_dict = process_external_completed_tasks(task)['data']
+            task = queryset.first().get_simple_formatted_task()
+            perform_dict = process_external_completed_tasks(task)["data"]
         else:
             workflow = self.get_workflow()
             perform_dict = {


### PR DESCRIPTION
I needed to encode the task from the `Task` type to a `dict` type. Also took the liberty to change which sample we return, returning the most recently completed one.

I replicated the Zapier call locally this time to test it:

```
Bernats-MBP:hl-rest-api bernat$ curl http://localhost:8000/zapier/sample-data?workflow_id=4 -H "Accept: application/json" -H "Authorization: Token bb09d9c923a8b850b3891861ce481b4b2db6e85c"
[{"sentence":"AAA","sentence2":"OK","a_seq":{"true":true},"bin":true}]Bernats-MBP:hl-rest-api bernat$
```