### PR TITLE
Backend cold start latency improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY requirements.txt /code/
 RUN pip install -r requirements.txt
 COPY . /code/
 EXPOSE 8000
-CMD gunicorn hl_rest_api.wsgi -b 0.0.0.0:8000 -w 1
+CMD gunicorn hl_rest_api.wsgi -b 0.0.0.0:8000 -w 1 -t 1 --timeout 0 --preload


### PR DESCRIPTION
It seems like setting a minimum number of instances to be permanently up doesn't really help, since the gunicorn workers still seem to be spinning up in the logs on every request after a period of inactivity.

I'm running a separate instance on this branch and will be testing out some things to try to reduce this delay.