### PR TITLE
Cloud run doesn't like HTTP 204 with an accompanying body

### DIFF
--- a/user_handler/views.py
+++ b/user_handler/views.py
@@ -181,7 +181,7 @@ class RetrieveUpdateRemoveUserOrgView(RetrieveUpdateDestroyAPIView):
                     self.request.user.pk, "Removed from Org", {"orgs_left": False}
                 )
                 return Response(
-                    {"status_code": 204, "message": "User was deleted"}, status=204
+                    {"status_code": 200, "message": "User was deleted"}, status=200
                 )
             else:
                 org = all_orgs_member.get(pk=kwargs["org_id"])
@@ -192,10 +192,10 @@ class RetrieveUpdateRemoveUserOrgView(RetrieveUpdateDestroyAPIView):
                 )
                 return Response(
                     {
-                        "status_code": 204,
+                        "status_code": 200,
                         "message": "User was deleted from organization",
                     },
-                    status=204,
+                    status=200,
                 )
 
 


### PR DESCRIPTION
Same issue we had with `/next` just happened with user deletion. See https://trello.com/c/2TdmsSNv

The success toast modals might have relied on the message in the body of the response, need to test alongside the frontend, both for invites and users.

[ ] Test deleting an invite
[ ] Test deleting a user