### PR TITLE
Move sync after save because we don't want it to modify the task's value

### DIFF
--- a/workflow_handler/views.py
+++ b/workflow_handler/views.py
@@ -331,7 +331,6 @@ class RUDTaskView(RetrieveUpdateAPIView):
         workflow = Workflow.objects.get(id=self.kwargs["workflow_id"])
         queryset = self.get_queryset()
         obj = get_object_or_404(queryset, id=self.kwargs["task_id"], workflow=workflow)
-        sync_workflow_task(workflow, obj)
         if obj.status in ["new", "pending", "open"]:
             obj.assigned_to = request.user
             obj.status = "in_progress"
@@ -343,6 +342,7 @@ class RUDTaskView(RetrieveUpdateAPIView):
                 action="assigned",
                 assignee=request.user,
             ).save()
+        sync_workflow_task(workflow, obj)
         task = self.serializer_class(obj).data
         task["status_code"] = 200
         return Response(task, status=200)


### PR DESCRIPTION
We have an issue with the new `use_placeholder` setting where the sync function may alter the state of `value`. We need to ensure the task is not persisted to the DB after a sync because the user might later set `use_placeholder` to `false` and we want `value` to contain the original value (empty or null), not the `placeholder`.