### PR TITLE
Add correct field in internal task representation

### DIFF
--- a/workflow_handler/models.py
+++ b/workflow_handler/models.py
@@ -97,6 +97,7 @@ class Task(models.Model):
             "source": source_name,
             "source_id": source_id,
             "n_comments": self.taskactivity_set.filter(action="comment").count(),
+            "correct": self.correct,
         }
 
     def get_simple_formatted_task(self):


### PR DESCRIPTION
Adding the audit decision field – aka `correct` – so it can be displayed in the Audits view