### PR TITLE
Add NER handling in CSV header check

### DIFF
--- a/data_handler/csv_utils.py
+++ b/data_handler/csv_utils.py
@@ -34,7 +34,6 @@ def validate_keys(title_row, workflow):
             value_count = title_row.count(winput["id"])
             if value_count > 1:
                 raise Exception("There are duplicate column names")
-            # TO-DO: Do we need this check? It should be fine to supply an incomplete task
             if value_count == 0:
                 raise Exception("The dataset is missing some columns")
 
@@ -70,7 +69,6 @@ def extract_ner(data_item, row, title_row):
             data_item[data_item["type"]]["value"] = input_value
 
 
-# TO-DO: modify to accept sub-keys for NER
 def extract_value(w_data, row, title_row):
     data_item = copy.deepcopy(w_data)
     if "layout" in data_item:

--- a/workflow_handler/views.py
+++ b/workflow_handler/views.py
@@ -264,13 +264,6 @@ class FileUploadView(APIView):
         filename = request.data["file"].name
         source = Source(name=filename, workflow=workflow, created_by=request.user)
         source.save()
-        process_csv(
-            content,
-            workflow=workflow,
-            source=source,
-            user=request.user,
-            filename=filename,
-        )
         try:
             process_csv(
                 content,


### PR DESCRIPTION
Right now importing data for the NER block through CSV involves scripting to generate the JSON formatted payload that goes into the NER column, which practically defeats the whole purpose of CSV import in the first place.

Importing into NER through CSV will almost always mean importing text for tagging, so we should support a variant whereby supplying a column called `<ner_id>.text` is analogous to supplying `{"<ner_id>": {"text": "", "entities": null}}`

To-do:

- [x] Add support for `<ner_id>.text` in the header
- [x] Pack values in the `<ner_id>.text` column into the `text` property of the NER block 