### PR TITLE
Add AST parsing to non-string types in CSV

### DIFF
--- a/data_handler/csv_utils.py
+++ b/data_handler/csv_utils.py
@@ -1,7 +1,6 @@
 import ast
 import copy
 import csv
-import re
 
 from django.db.models import F
 from django.http import HttpResponse
@@ -37,17 +36,6 @@ def validate_keys(title_row, workflow):
                 raise Exception("There are duplicate column names")
             if value_count == 0:
                 raise Exception("The dataset is missing some columns")
-
-
-def clean_str_json(input_value):
-    # Handle emptiness
-    if len(input_value) < 1:
-        return "{}"
-    # Handle wrapping single quotes, which could be part of the CSV but make JSON parsing fail
-    if re.match(r"^[\'].*[\']$", input_value):
-        return input_value[1:-1]
-    # Otherwise return original
-    return input_value
 
 
 # NER is a special case since it follows a different set of conventions


### PR DESCRIPTION
CSV importing doesn't work for non-string types in CSV exported files. That's because our CSV import logic doesn't account for non-string types, which get treated as strings by the CSV reader and thus by the subsequent logic. This is fine as the default, but we should use `ast` to parse Python literals from those strings for relevant types.

This PR has POC code that works for all types but NER. Left to do:

- [x] Add NER support
- [x] Tidy up