### PR TITLE
Add start and end date filter for completed tasks endpoints

### DIFF
--- a/external/views.py
+++ b/external/views.py
@@ -12,6 +12,7 @@ from user_handler.notifications import send_notification
 from user_handler.permissions import IsOrgAdmin
 from workflow_handler.audits import GetCompletedTaskView
 from workflow_handler.models import Task, Workflow
+from workflow_handler.utils import parse_dates
 
 from .serializers import ExternalTaskSerializer
 
@@ -46,7 +47,11 @@ class GetExternalCompletedTaskView(GetCompletedTaskView):
         )
         return (
             Task.objects.defer("data")
-            .filter(Q(workflow=workflow) & Q(status="completed"))
+            .filter(
+                Q(workflow=workflow)
+                & Q(status="completed")
+                & Q(completed_at__range=(parse_dates(self.request)))
+            )
             .filter(*args, **kwargs)
             .order_by("-completed_at")
         )

--- a/workflow_handler/audits.py
+++ b/workflow_handler/audits.py
@@ -19,7 +19,7 @@ from .serializers import (
     TaskMetadataSerializer,
     TaskSerializer,
 )
-from .utils import TaskPagination, process_query_params
+from .utils import TaskPagination, parse_dates, process_query_params
 
 
 def make_task_filter_url(org_id, task_id, filters):
@@ -48,7 +48,11 @@ class GetCompletedTaskView(ListAPIView):
         )
         return (
             Task.objects.defer("data")
-            .filter(Q(workflow__in=workflows) & Q(status="completed"))
+            .filter(
+                Q(workflow__in=workflows)
+                & Q(status="completed")
+                & Q(completed_at__range=(parse_dates(self.request)))
+            )
             .filter(*args, **kwargs)
             .order_by("-completed_at")
         )
@@ -79,7 +83,11 @@ class GetCompletedTasksCSVView(APIView):
         )
         return (
             Task.objects.defer("data")
-            .filter(Q(workflow__in=workflows) & Q(status="completed"))
+            .filter(
+                Q(workflow__in=workflows)
+                & Q(status="completed")
+                & Q(completed_at__range=(parse_dates(self.request)))
+            )
             .filter(*args, **kwargs)
             .order_by("completed_at")
         )

--- a/workflow_handler/tests/test_get_task_list.py
+++ b/workflow_handler/tests/test_get_task_list.py
@@ -70,7 +70,7 @@ class TestInternalTaskList(APITestCase):
         t_delta = timezone.timedelta(0)
         for task in Task.objects.all()[: self.completed_tasks]:
             task.status = "completed"
-            task.completed_at = timezone.now() - t_delta
+            task.completed_at = timezone.now() + t_delta
             t_delta -= timezone.timedelta(minutes=10)
             task.save()
 

--- a/workflow_handler/utils.py
+++ b/workflow_handler/utils.py
@@ -1,13 +1,32 @@
 import copy
+import datetime
 
 import cchardet
 from django.utils import timezone
+from django.utils.timezone import make_aware
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 
 from .models import WebHook, Workflow, WorkflowNotification
 
 TEMPLATE_ORG_ID = 40
+
+
+def parse_dates(request):
+    try:
+        start_date = datetime.datetime.fromisoformat(
+            request.query_params.get("start_date")
+        )  # YYYY-MM-DD
+    except:
+        start_date = datetime.datetime(2019, 1, 1)
+    try:
+        end_date = datetime.datetime.fromisoformat(
+            request.query_params.get("end_date")
+        )  # YYYY-MM-DD
+        end_date += datetime.timedelta(days=1, microseconds=-1)
+    except:
+        end_date = datetime.datetime.today()
+    return make_aware(start_date), make_aware(end_date)
 
 
 def find_and_fire_hook(event_name, instance, **kwargs):


### PR DESCRIPTION
Adding optional `start_date` and `end_date` query parameters for the internal and external completed task and CSV generation endpoints.