### PR TITLE
Enforce psycopg2 2.8.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ google-cloud-storage = "1.36.0"
 click = "7.1.2"
 whitenoise = "^5.2.0"
 django-rest-hooks-tmp = "1.6.1"
-psycopg2-binary = "^2.8.6"
+psycopg2-binary = "~2.8.6"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.12.1"


### PR DESCRIPTION
I want to address to the following warning:

```
ERROR 2021-06-21 13:33:40,907 Internal Server Error: /v1/orgs/1/queues
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/generics.py", line 199, in get
    return self.list(request, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/human_lambdas/workflow_handler/views.py", line 135, in list
    for d in serializer.data:
  File "/usr/local/lib/python3.8/site-packages/rest_framework/serializers.py", line 745, in data
    ret = super().data
  File "/usr/local/lib/python3.8/site-packages/rest_framework/serializers.py", line 246, in data
    self._data = self.to_representation(self.instance)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/serializers.py", line 663, in to_representation
    return [
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 274, in __iter__
    self._fetch_all()
[tool.poetry]
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 1242, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 55, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/usr/local/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1173, in execute_sql
    return list(result)
  File "/usr/local/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1552, in cursor_iter
    for rows in iter((lambda: cursor.fetchmany(itersize)), sentinel):
  File "/usr/local/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1552, in <lambda>
    for rows in iter((lambda: cursor.fetchmany(itersize)), sentinel):
  File "/usr/local/lib/python3.8/site-packages/django/db/utils.py", line 96, in inner
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/postgresql/utils.py", line 6, in utc_tzinfo_factory
    raise AssertionError("database connection isn't set to UTC")
AssertionError: database connection isn't set to UTC
```

Proposed solution: https://stackoverflow.com/questions/68024060/assertionerror-database-connection-isnt-set-to-utc